### PR TITLE
fix react16

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class ImageView extends Component {
                     onSingleTap={this.onSingleTap.bind(this)}
                     onPressMove={this.onPressMove.bind(this)}
                     onSwipe={this.onSwipe.bind(this)}>
-                    <ul ref="imagelist" className="imagelist">
+                    <ul ref={(imagelist) => {this.list = imagelist;}} className="imagelist">
                     {
                         this.props.imagelist.map((item, i) => {
                             return (
@@ -119,7 +119,7 @@ class ImageView extends Component {
             { imagelist, initCallback } = this.props;
 
         this.arrLength = imagelist.length;
-        this.list = this.refs['imagelist'];
+        // this.list = this.refs['imagelist'];
 
         Transform(this.list);
 


### PR DESCRIPTION
当使用react16引用该插件时将报错（如下图），因为react16不允许给ref直接设置字符串，使用回调函数处理即可兼容react16。
![hg_8 if7_2 xp6 zp4r p](https://user-images.githubusercontent.com/24218298/35721157-b43856f4-082b-11e8-8670-8f23c68b7d07.png)
